### PR TITLE
update depencies to be more lenient

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
   "author": "Tony Sokhon",
   "license": "MIT",
   "peerDependencies": {
-    "redis": "~0.9.0"
+    "redis": "0.x"
   },
   "devDependencies": {
-    "redis": "~0.9.0",
-    "hiredis": "~0.1.15"
+    "redis": "0.x",
+    "hiredis": "0.x"
   }
 }


### PR DESCRIPTION
redis package has been updated to 0.10.0 which means it is not
compatible with the current dependency specification.

If we depend on semver then we should only need to specify 0.x as we
can assume that only changes in the redis package's major version will
break this plugin.
