### PR TITLE
Value Storage & Options Object

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,15 +82,22 @@ You can find basic usage examples in `examples`. This module also powers a [real
 	// Returns "count" chunks of counters at the precision described by
 	// "granularity_label"
 	// 
-	ts.getHits('your_stats_key', granularity_label, count, function(err, data) {
-		// data.length == count
-		// data = [ [ts1, count1], [ts2, count2]... ]
+	ts.getHits('your_stats_key', granularity_label, opts, function(err, data) {
+		// opts = {
+			// count : (int) how many time slices to scan back
+			// backfill : (bool) whether or not to create and set 0 values to slices where no hits were recorded
+		// }
+		// data = [ [ts1, hitCount1], [ts2, hitCount2]... ]
 	});
 
 	// getValues is identical to getHits except that it returns a null value for unset timestamps
-	ts.getValues('your_stats_key', granularity_label, count, function(err, data) {
-		// data.length == count
-		// data = [ [ts1, count1], [ts2, count2]... ]
+	ts.getValues('your_stats_key', granularity_label, opts, function(err, data) {
+		// opts = {
+			// count : (int) how many time slices to scan back
+			// backfill : (bool) whether or not to create a record for slices with no set events
+			// backfillLastSet : (bool) whether or not to use the last-set value for slices with no set events (default, false results in value null)
+		// }
+		// data = [ [ts1, value1], [ts2, value2]... ]
 	});
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ You can find basic usage examples in `examples`. This module also powers a [real
     // It's also possible to decrement the hits counter for
     // some key
     ts.removeHit('your_stats_key', [timestamp]).exec();
+
+    // Recording values
+	//
+	// This sets the value for the
+	// stats keys you provide
+	//
+	// "timestamp" defaults to the current time
+    // "increment" defaults to 1
+	//
+	ts.recordHit('your_stats_key')
+	  .recordHit('another_stats_key', timestamp)
+      .recordHit('another_stats_key', timestamp2, increment)
+	  …
+	  .exec();
 	  
 	// Querying statistics
 	//
@@ -54,6 +68,12 @@ You can find basic usage examples in `examples`. This module also powers a [real
 	// "granularity_label"
 	// 
 	ts.getHits('your_stats_key', granularity_label, count, function(err, data) {
+		// data.length == count
+		// data = [ [ts1, count1], [ts2, count2]... ]
+	});
+
+	// getValues is identical to getHits except that it returns a null value for unset timestamps
+	ts.getValues('your_stats_key', granularity_label, count, function(err, data) {
 		// data.length == count
 		// data = [ [ts1, count1], [ts2, count2]... ]
 	});

--- a/README.md
+++ b/README.md
@@ -56,9 +56,7 @@ You can find basic usage examples in `examples`. This module also powers a [real
 	// "timestamp" defaults to the current time
     // "increment" defaults to 1
 	//
-	ts.recordHit('your_stats_key')
-	  .recordHit('another_stats_key', timestamp)
-      .recordHit('another_stats_key', timestamp2, increment)
+	ts.recordValue('your_stats_key', timestamp, value)
 	  …
 	  .exec();
 	  

--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ You can find basic usage examples in `examples`. This module also powers a [real
     //
     // Decrements the hits for a specified point in time.
     ts.removeHit('your_stats_key', [timestamp]).exec();
+
+    // Recording values
+	//
+	// This sets the value for the
+	// stats keys you provide
+	//
+	// "timestamp" defaults to the current time
+    // "increment" defaults to 1
+	//
+	ts.recordValue('your_stats_key', timestamp, value)
+	  …
+	  .exec();
     
     // Decrement defaults to 1, but can be specified explicitly (below).
     ts.removeHit('your_stats_key', [timestamp], 5).exec();

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Tony Sokhon",
   "license": "MIT",
   "peerDependencies": {
-    "redis": "*"
+    "redis": "0.x"
   },
   "devDependencies": {
     "redis": "0.x",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Tony Sokhon",
   "license": "MIT",
   "peerDependencies": {
-    "redis": "0.x"
+    "redis": "*"
   },
   "devDependencies": {
     "redis": "0.x",

--- a/test/concurrentTest.js
+++ b/test/concurrentTest.js
@@ -21,6 +21,7 @@ vows.describe('TimeSeries Tests').addBatch({
       var date = Math.floor(Date.now() / 1000);
       //date = date.getTime() / 1000;
       var backDate = date - 7200; // 3 hours
+      var backBackDate = date - 14400; // 6 hours
 
       // Reduce granularities for easier testing
       ts.granularities = {
@@ -71,6 +72,7 @@ vows.describe('TimeSeries Tests').addBatch({
       tasks.push(recordValue('valueKey', date, 1));
       tasks.push(recordValue('valueKey', date, 1));
       tasks.push(recordValue('valueKey', backDate, 2));
+      tasks.push(recordValue('valueKey', backBackDate, 3));
       tasks.push(getValues({ backfill : false }));
       tasks.push(getValues({ backfillLastValue : false }));
       tasks.push(getValues());
@@ -84,9 +86,11 @@ vows.describe('TimeSeries Tests').addBatch({
 
       redis.flushdb();
 
+      console.log(results[results.length-5])
+
       assert.deepEqual(results[results.length-5], [ 2, 1 ])
       assert.deepEqual(results[results.length-4], [ null, 2, null, 1 ])
-      assert.deepEqual(results[results.length-3], [ null, 2, 2, 1 ])
+      assert.deepEqual(results[results.length-3], [ 3, 2, 2, 1 ])
       assert.deepEqual(results[results.length-2], [ 15 ])
       assert.deepEqual(results[results.length-1], [ 0, 0, 0, 15 ])
 

--- a/test/concurrentTest.js
+++ b/test/concurrentTest.js
@@ -11,10 +11,16 @@ function range(n) {
   return Array.apply(null, Array(n)).map(function (_, i) {return i;});
 }
 
+
 vows.describe('TimeSeries Tests').addBatch({
   'When recording hits concurrently': {
     topic: function() {
       var ts = new TimeSeries(redis);
+      redis.flushdb();
+
+      var date = Math.floor(Date.now() / 1000);
+      //date = date.getTime() / 1000;
+      var backDate = date - 7200; // 3 hours
 
       // Reduce granularities for easier testing
       ts.granularities = {
@@ -24,23 +30,66 @@ vows.describe('TimeSeries Tests').addBatch({
       // Build N concurrent hit queries
       function handler(i) {
         return function(callback) {
-          ts.recordHit('key_'+i).exec(callback);
+          ts.recordHit('key_'+i).recordHit('key').exec(callback);
+        };
+      }
+
+      function getHits(opts) {
+        return function(callback) {
+          opts = opts || {}
+          opts.count = opts.count || 4
+          ts.getHits('key', 'h', opts, function(err, data){
+            data = range(data.length).map(function(res) { return data[res][1]; });
+            callback(err, data);
+          });
+        };
+      }
+
+      function recordValue(key, d, i) {
+        return function(callback) {
+          ts.recordValue('valueKey', d, i).exec(callback);
         };
       }
       
+      function getValues(opts) {
+        return function(callback) {
+          opts = opts || {}
+          opts.count = opts.count || 4
+          ts.getValues('valueKey', 'h', opts, function(err, data){
+            data = range(data.length).map(function(res) { return data[res][1]; });
+            callback(err, data);
+          });
+        };
+      }
+
       // Select non-default test db
       redis.select(9);
-      redis.flushdb();
+      //redis.flushdb();
 
-      async.parallel(range(N).map(handler), this.callback);
+      var tasks = range(N).map(handler);
+      //console.log(tasks);
+      tasks.push(recordValue('valueKey', date, 1));
+      tasks.push(recordValue('valueKey', date, 1));
+      tasks.push(recordValue('valueKey', backDate, 2));
+      tasks.push(getValues({ backfill : false }));
+      tasks.push(getValues({ backfillLastValue : false }));
+      tasks.push(getValues());
+      tasks.push(getHits({ backfill : false }));
+      tasks.push(getHits());
+
+      async.parallel(tasks, this.callback);
     },
 
     "we get correct results": function(results) {
+
       redis.flushdb();
 
-      var expected = range(N).map(function() { return [1,1]; });
+      assert.deepEqual(results[results.length-5], [ 2, 1 ])
+      assert.deepEqual(results[results.length-4], [ null, 2, null, 1 ])
+      assert.deepEqual(results[results.length-3], [ null, 2, 2, 1 ])
+      assert.deepEqual(results[results.length-2], [ 15 ])
+      assert.deepEqual(results[results.length-1], [ 0, 0, 0, 15 ])
 
-      assert.deepEqual(results, expected);
     }
   }
 }).export(module);


### PR DESCRIPTION
Hey @tonyskn - this pull request adds the ability for the TimeSeries object to record values as well. It is set up to save and retrieve a value recorded during a time slice. 

I've been using my own branch for a while and it's been useful to track the current value and history of a key. This is useful for recording things such as historical temperature or # "likes over time" while utilizing a similar get function as the hit counter.

I've also replaced the count param with an opts object (see updated README for more) but set things up so that an integer is still accepted. No existing functions were modified in a way that prevents backwards compatibility.This will add a bit of flexibility in building more features in the future.

Sorry for the messy commits - I'm just running and gunning over here!

Edit - I've also improved the testing coverage and applied it to the new functions as well.
